### PR TITLE
Add avcode.h to decoder example

### DIFF
--- a/decoder_use/main.c
+++ b/decoder_use/main.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include "libavformat/avformat.h"
+#include "libavcodec/avcodec.h"
+
 int main()
 {
     AVFormatContext *fmt_ctx = NULL;


### PR DESCRIPTION
Many avcodec struct and function prototypes are in avcodec.h which is not included in the decoder_user example, which causes compilation issue.